### PR TITLE
chore: Make 0.6 syntax changes

### DIFF
--- a/examples/net.gr
+++ b/examples/net.gr
@@ -1,7 +1,7 @@
 module Net
 
 include "lunatic"
-from Lunatic use { Net }
+from Lunatic use { module Net }
 
 provide let _start = () => {
   match (Net.DNS.resolve("google.com:80")) {

--- a/examples/simpleProcess.gr
+++ b/examples/simpleProcess.gr
@@ -1,7 +1,7 @@
 module Main
 
 include "lunatic"
-from Lunatic use { Process }
+from Lunatic use { module Process }
 
 @externalName("_start")
 provide let main = () => {

--- a/examples/sleep.gr
+++ b/examples/sleep.gr
@@ -1,7 +1,7 @@
 module Sleep
 
 include "lunatic"
-from Lunatic use { Process }
+from Lunatic use { module Process }
 
 provide let _start = () => {
   print("Counting...")

--- a/examples/spawn.gr
+++ b/examples/spawn.gr
@@ -5,7 +5,7 @@ include "int64"
 include "result"
 
 include "lunatic"
-from Lunatic use { Process }
+from Lunatic use { module Process }
 
 record SomeData<a> {
   key: String,

--- a/examples/version.gr
+++ b/examples/version.gr
@@ -1,7 +1,7 @@
 module Version
 
 include "lunatic"
-from Lunatic use { Version }
+from Lunatic use { module Version }
 
 let semverString = (major, minor, patch) => {
   let (major, minor, patch) = (

--- a/lunatic.gr
+++ b/lunatic.gr
@@ -4,4 +4,4 @@ include "./src/net"
 include "./src/process"
 include "./src/version"
 
-provide { Net, Process, Version }
+provide { module Net, module Process, module Version }

--- a/src/net.gr
+++ b/src/net.gr
@@ -46,7 +46,7 @@ provide module DNS {
   @unsafe
   let resolveDNSIterator = id => {
     let add = (+)
-    let (+) = WasmI32.add
+    from WasmI32 use { (+) }
 
     let mut addresses = []
 
@@ -64,8 +64,7 @@ provide module DNS {
     ) {
       let address = match (WasmI32.load(ipPointer, _TYPE_OFFSET)) {
         4n => {
-          let (<<) = WasmI32.shl
-          let (|) = WasmI32.or
+          from WasmI32 use { (<<), (|) }
 
           // These bytes are big endian, but WebAssembly is little endian
 
@@ -78,8 +77,7 @@ provide module DNS {
           IPv4(WasmI32.toGrain(DataStructures.newInt32(ip)))
         },
         6n => {
-          let (<<) = WasmI64.shl
-          let (|) = WasmI64.or
+          from WasmI64 use { (<<), (|) }
 
           // These bytes are big endian, but WebAssembly is little endian
 
@@ -138,7 +136,8 @@ provide module DNS {
 
   @unsafe
   provide let resolveTimeout = (host: String, timeout: Int64) => {
-    let hostPtr = WasmI32.add(WasmI32.fromGrain(host), 8n)
+    from WasmI32 use { (+) }
+    let hostPtr = WasmI32.fromGrain(host) + 8n
     let hostSize = WasmI32.load(WasmI32.fromGrain(host), 4n)
 
     let timeout = WasmI64.load(WasmI32.fromGrain(timeout), 8n)
@@ -181,7 +180,7 @@ provide module Tcp {
 
   @unsafe
   provide let bind = address => {
-    from WasmI32 use { add as (+) }
+    from WasmI32 use { (+) }
 
     let addresses = DNS.resolve(address)
     let ip = match (addresses) {
@@ -250,7 +249,7 @@ provide module Tcp {
 
   @unsafe
   provide let read = (stream: TcpStream, buffer: Bytes) => {
-    from WasmI32 use { add as (+) }
+    from WasmI32 use { (+) }
 
     let streamId = WasmI64.load(WasmI32.fromGrain(stream), 8n)
     let mut bufPtr = WasmI32.fromGrain(buffer)
@@ -270,7 +269,7 @@ provide module Tcp {
 
   @unsafe
   provide let write = (stream: TcpStream, buffer: Bytes) => {
-    from WasmI32 use { add as (+) }
+    from WasmI32 use { (+) }
 
     let streamId = WasmI64.load(WasmI32.fromGrain(stream), 8n)
     let mut bufPtr = WasmI32.fromGrain(buffer)

--- a/src/process.gr
+++ b/src/process.gr
@@ -74,12 +74,13 @@ abstract type Mailbox<a> = Int64
 @unsafe
 let mut currentTag = 128N
 
-let bootstrapMailbox: Mailbox<() -> Void> = 1L
+let bootstrapMailbox: Mailbox<() => Void> = 1L
 
 @unsafe
 provide let createMailbox = () => {
+  from WasmI64 use { (+) }
   let tag = currentTag
-  currentTag = WasmI64.add(currentTag, 1N)
+  currentTag += 1N
   WasmI32.toGrain(DataStructures.newInt64(tag)): Mailbox<a>
 }
 
@@ -95,21 +96,17 @@ let createData = (tag: Int64, capacity: Int64) => {
 
 @unsafe
 let writeData = (bytes: Bytes) => {
+  from WasmI32 use { (+) }
   let bytesPtr = WasmI32.fromGrain(bytes)
-  let bytesWritten = writeData(
-    WasmI32.add(bytesPtr, 8n),
-    WasmI32.load(bytesPtr, 4n)
-  )
+  let bytesWritten = writeData(bytesPtr + 8n, WasmI32.load(bytesPtr, 4n))
   WasmI32.toGrain(DataStructures.newInt32(bytesWritten)): Int32
 }
 
 @unsafe
 let readData = (bytes: Bytes) => {
+  from WasmI32 use { (+) }
   let bytesPtr = WasmI32.fromGrain(bytes)
-  let bytesRead = readData(
-    WasmI32.add(bytesPtr, 8n),
-    WasmI32.load(bytesPtr, 4n)
-  )
+  let bytesRead = readData(bytesPtr + 8n, WasmI32.load(bytesPtr, 4n))
   WasmI32.toGrain(DataStructures.newInt32(bytesRead)): Int32
 }
 
@@ -141,6 +138,7 @@ let sendRaw = (process: Process) => {
 
 @unsafe
 let receive = (tags: Option<List<Int64>>, timeout: Uint64) => {
+  from WasmI32 use { (*), (+) }
   let tags = match (tags) {
     Some(tags) => Array.fromList(tags),
     None => [>],
@@ -148,16 +146,16 @@ let receive = (tags: Option<List<Int64>>, timeout: Uint64) => {
 
   let count = DataStructures.untagSimpleNumber(Array.length(tags))
 
-  let tagsBuf = Memory.malloc(WasmI32.mul(count, 8n))
+  let tagsBuf = Memory.malloc(count * 8n)
 
-  for (let mut i = 0n; WasmI32.ltU(i, count); i = WasmI32.add(i, 1n)) {
+  for (let mut i = 0n; WasmI32.ltU(i, count); i += 1n) {
     WasmI64.store(
       tagsBuf,
       WasmI64.load(
         WasmI32.fromGrain(tags[DataStructures.tagSimpleNumber(i)]),
         8n
       ),
-      WasmI32.mul(i, 8n)
+      i * 8n
     )
   }
 
@@ -182,7 +180,7 @@ let idPtr = Memory.malloc(8n)
 
 /**
  * Cause the current process to sleep for the given number of milliseconds.
- * 
+ *
  * @param ms: The number of milliseconds to sleep
  */
 @unsafe
@@ -199,7 +197,7 @@ provide let this = () => {
 }
 
 @unsafe
-provide let send: (Process, a, Mailbox<a>) -> Result<Void, Exception> =
+provide let send: (Process, a, Mailbox<a>) => Result<Void, Exception> =
   (
     process,
     data,
@@ -211,7 +209,7 @@ provide let send: (Process, a, Mailbox<a>) -> Result<Void, Exception> =
   sendRaw(process)
 }
 
-provide let receive: (?timeout: Uint64, Mailbox<a>) -> Result<a, Exception> =
+provide let receive: (?timeout: Uint64, Mailbox<a>) => Result<a, Exception> =
   (
     timeout=0xffffffffffffffffuL,
     mailbox,
@@ -250,14 +248,15 @@ provide let takeTcpStream = () => {
 }
 
 @unsafe
-provide let spawn = (func: () -> Void) => {
+provide let spawn = (func: () => Void) => {
+  from WasmI32 use { (+) }
   let funcName = WasmI32.fromGrain("__lunatic_bootstrap")
 
   let result = spawn(
     0N,
     -1N,
     -1N,
-    WasmI32.add(funcName, 8n),
+    funcName + 8n,
     WasmI32.load(funcName, 4n),
     0n,
     0n,
@@ -281,9 +280,10 @@ provide let spawn = (func: () -> Void) => {
 
 @unsafe
 provide let register = (name: String, process: Process) => {
+  from WasmI32 use { (+) }
   let namePtr = WasmI32.fromGrain(name)
   let nameLen = WasmI32.load(namePtr, 4n)
-  let namePtr = WasmI32.add(namePtr, 8n)
+  let namePtr = namePtr + 8n
 
   let nodeIdValue = WasmI64.load(WasmI32.fromGrain(process.nodeId), 8n)
   let processId = WasmI64.load(WasmI32.fromGrain(process.pid), 8n)
@@ -296,19 +296,15 @@ provide let register = (name: String, process: Process) => {
 
 @unsafe
 provide let lookup = (name: String) => {
+  from WasmI32 use { (+) }
   let namePtr = WasmI32.fromGrain(name)
   let nameLen = WasmI32.load(namePtr, 4n)
-  let namePtr = WasmI32.add(namePtr, 8n)
+  let namePtr = namePtr + 8n
 
   let nodeId = DataStructures.allocateInt64()
   let pid = DataStructures.allocateInt64()
 
-  let err = Registry.get(
-    namePtr,
-    nameLen,
-    WasmI32.add(nodeId, 8n),
-    WasmI32.add(pid, 8n)
-  )
+  let err = Registry.get(namePtr, nameLen, nodeId + 8n, pid + 8n)
   if (WasmI32.eqz(err)) {
     Some({ nodeId: WasmI32.toGrain(nodeId), pid: WasmI32.toGrain(pid) })
   } else {
@@ -320,9 +316,10 @@ provide let lookup = (name: String) => {
 
 @unsafe
 provide let deregister = (name: String) => {
+  from WasmI32 use { (+) }
   let namePtr = WasmI32.fromGrain(name)
   let nameLen = WasmI32.load(namePtr, 4n)
-  let namePtr = WasmI32.add(namePtr, 8n)
+  let namePtr = namePtr + 8n
 
   Registry.remove(namePtr, nameLen)
 
@@ -343,7 +340,7 @@ provide let __lunatic_bootstrap = () => {
   // The mailbox type is not propagated within this module for some reason so
   // we use an explicit type annotation.
   // https://github.com/grain-lang/grain/issues/1356
-  let result: Result<() -> Void, Exception> = receive(bootstrapMailbox)
+  let result: Result<() => Void, Exception> = receive(bootstrapMailbox)
   match (result) {
     Ok(func) => func(),
     Err(ReceiveTimeout) => fail "didn't receive bootstrap message",


### PR DESCRIPTION
This brings the `lunatic` bindings up to date with the current state of `v0.6`